### PR TITLE
Remove unused einops import

### DIFF
--- a/modeling/backbone/utils.py
+++ b/modeling/backbone/utils.py
@@ -4,7 +4,6 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
-from einops import rearrange, repeat, pack, unpack
 from functools import partial
 from collections import namedtuple
 from torch import Tensor, nn, einsum
@@ -30,12 +29,6 @@ def default(val, d):
 
 def divisible_by(numer, denom):
     return (numer % denom) == 0
-
-def pack_one(t, pattern):
-    return pack([t], pattern)
-
-def unpack_one(t, ps, pattern):
-    return unpack(t, ps, pattern)[0]
 
 def pad_to_multiple(tensor, multiple, dim=-1, value=0):
     seq_len = tensor.shape[dim]


### PR DESCRIPTION
`requirements.txt` does not mention `einops` and the repository does not contain any functions with `pack` in their name, so this should be safe to remove. This way, the example does not crash with `ModuleNotFoundError: No module named 'einops'` anymore.

I ran the inference example [from the README](https://github.com/linyiheng123/MEMatte?tab=readme-ov-file#inference) and got the following numbers, which are even better than MSE 15.2 and SAD 18.88 from [the paper](https://arxiv.org/pdf/2412.10702) (Table 5 Row 6). Excellent job!

```
MSE: 15.17
SAD: 18.74
```

I used `opencv-python==4.13.0.92`, which is the current latest version, because the pinned version failed to install within my environment. In addition, I am using `torch==2.10.0+cu130` instead of the suggested version 2.0.0, which also seems to work.